### PR TITLE
Fix for debugger being disabled

### DIFF
--- a/ht8b.cs
+++ b/ht8b.cs
@@ -743,7 +743,9 @@ void _onlocal_gameover()
 {
    _vis_apply_tablecolour( sn_winnerid );
 
+#if HT8B_DEBUGGER
    _frp( FRP_WARN + sn_packetid + " >> local: " + local_playerid + " Winner: " + sn_winnerid + FRP_END );
+#endif
 
    if( start_saved_players[ sn_winnerid ] != null )
    {


### PR DESCRIPTION
This should fix a problem when the debugger is disabled, it won't throw an error and cause the scene to not be buildable. This was referenced in Issue #59